### PR TITLE
Fixing wrong headers for downloads

### DIFF
--- a/Sources/FileUploads/FileController.swift
+++ b/Sources/FileUploads/FileController.swift
@@ -89,7 +89,8 @@ class FileController {
 				let contents = try thisFile.readString()
 			
 				response.setBody(string: "Downloading \(contents)...")
-					.setHeader(.contentType, value: "Content-Disposition: attachment; filename=\"\(fileName)\"")
+					.setHeader(.contentDisposition, value: "attachment; filename=\"\(fileName)\"")
+          .setHeader(.contentType, value: "text/plain")
 					.completed()
 				
 			}catch{


### PR DESCRIPTION
**NOTE** it only works for text file. Please check content type specification for more details:

[content types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type)